### PR TITLE
Fixed multipleSchemaDepViolation test failure by swapping

### DIFF
--- a/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
+++ b/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java
@@ -143,10 +143,14 @@ public class ObjectSchemaTest {
                 ageFailure = tmp;
             }
             ValidationException billingAddressFailure = creditCardFailure.getCausingExceptions().get(0);
+            ValidationException billingNameFailure = creditCardFailure.getCausingExceptions().get(1);
+            if(billingAddressFailure.getPointerToViolation().equals("#/billing_name")) {
+                ValidationException tmp = billingAddressFailure;
+                billingAddressFailure = billingNameFailure;
+                billingNameFailure = tmp;
+            }
             assertEquals("#/billing_address", billingAddressFailure.getPointerToViolation());
             assertEquals(billingAddressSchema, billingAddressFailure.getViolatedSchema());
-            ValidationException billingNameFailure = creditCardFailure
-                    .getCausingExceptions().get(1);
             assertEquals("#/billing_name", billingNameFailure.getPointerToViolation());
             assertEquals(billingNameSchema, billingNameFailure.getViolatedSchema());
             assertEquals("#", ageFailure.getPointerToViolation());


### PR DESCRIPTION
Created this PR to fix 1 flaky test - [multipleSchemaDepViolation](https://github.com/everit-org/json-schema/blob/master/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java#L118)
--------------
1. **How were these test identified as flaky?**
This test was identified as flaky by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

2. **What was the error?**
The test uses `e.getCausingExceptions()` and acknowledges that getCausingExceptions() is non-deterministic and may give swapped order and thus, the test swaps the 0th and 1st element [here](https://github.com/everit-org/json-schema/blob/master/core/src/test/java/org/everit/json/schema/ObjectSchemaTest.java#L140) if the order is different from the expected order. The test is using getCausingExceptions() once for `ValidationException e` for which the swapping code has already been written, and getCausingExceptions() is used again on creditCardFailure for which the swapping code is missing. Due to this missing swapping code, sometimes the billingAddressFailure and billingNameFailure gets interchanged leading to the below error.

```
[ERROR] Failures: 
[ERROR]   ObjectSchemaTest.multipleSchemaDepViolation:146 expected: <#/billing_address> but was: <#/billing_name>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

3. **What is the fix?**
Inspired from fix already present for the first getCausingExceptions(), I have added the swapping code for the 2d getCausingExceptions() and made sure that the order is the expected order. 

--------------
You can run the following commands to run the test using NonDex tool:
```
mvn -pl core  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.everit.json.schema.ObjectSchemaTest#multipleSchemaDepViolation
```

Test Environment:
```
java version 11.0.19
Apache Maven 3.9.5
```
Kindly let me know if this fix is acceptable.
Thank you
